### PR TITLE
Enhancement/react proptypes migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "lodash": "^4.15.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0",
-    "react-native": ">=0.28.0"
+    "react": "16.0.0-alpha.13",
+    "react-native": ">=0.46.1",
+    "prop-types": "^15.5.10"
   },
   "keywords": [
     "React",

--- a/src/animations/FadeIn.js
+++ b/src/animations/FadeIn.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
 /*
@@ -35,12 +36,12 @@ export class FadeIn extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     /**
      * pair of [start, end] values from animation driver, how
      * children would fade in
      */
-    inputRange: React.PropTypes.array,
+    inputRange: PropTypes.array,
   }
 
   render() {

--- a/src/animations/FadeOut.js
+++ b/src/animations/FadeOut.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
 /*
@@ -35,13 +36,13 @@ export class FadeOut extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     /**
      * pair of [start, end] values from animation driver, how
      * children would fade out
      */
-    inputRange: React.PropTypes.array,
-    style: React.PropTypes.object,
+    inputRange: PropTypes.array,
+    style: PropTypes.object,
   }
 
   render() {

--- a/src/animations/HeroHeader.js
+++ b/src/animations/HeroHeader.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
 /*
@@ -32,7 +33,7 @@ export class HeroHeader extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
   }
   render() {
     const { driver, children } = this.props;

--- a/src/animations/Parallax.js
+++ b/src/animations/Parallax.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactNative, { Animated, View, Dimensions } from 'react-native';
 
 import { DriverShape } from '../drivers/DriverShape';
@@ -39,28 +40,28 @@ class Parallax extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     /**
      * extrapolation options for parallax translation
      * if not passed children would be translated by
      * scrollVector * (scrollSpeed - 1) * driver.value
      * where scroll vector is defined by scrolling direction
      */
-    extrapolation: React.PropTypes.object,
+    extrapolation: PropTypes.object,
     /**
      * how fast passed children would scroll
      */
-    scrollSpeed: React.PropTypes.number,
+    scrollSpeed: PropTypes.number,
     /**
      * Is Parallax placed in or outside the ScrollView
      */
-    insideScroll: React.PropTypes.bool,
+    insideScroll: PropTypes.bool,
     /**
      * Is parallax used as header
      */
-    header: React.PropTypes.bool,
+    header: PropTypes.bool,
 
-    style: React.PropTypes.object,
+    style: PropTypes.object,
   }
 
   static defaultProps = {

--- a/src/animations/Rotate.js
+++ b/src/animations/Rotate.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
 /*
@@ -34,21 +35,21 @@ export class Rotate extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     /**
      * pair of [start, end] values from animation driver, how
      * children would rotate by an angle in axis
      */
-    inputRange: React.PropTypes.array,
+    inputRange: PropTypes.array,
     /**
      * rotation angle e.g. "90deg"
      */
-    angle: React.PropTypes.string,
+    angle: PropTypes.string,
     /**
      * axis of rotation(x, y, z), z is default
      */
-    axis: React.PropTypes.string,
-    style: React.PropTypes.object,
+    axis: PropTypes.string,
+    style: PropTypes.object,
   };
 
   render() {

--- a/src/animations/Slide/Slide.js
+++ b/src/animations/Slide/Slide.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View } from './../View';
 import { DriverShape } from '../../drivers/DriverShape';
 import { measure } from '../../components/measure';
@@ -12,18 +13,18 @@ class Slide extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     /**
      * pair of [start, end] values from animation driver, how
      * children would slide
      */
-    inputRange: React.PropTypes.array,
+    inputRange: PropTypes.array,
     /**
      * direction of where children would slide to e.g. "top right"
      */
-    direction: React.PropTypes.string,
-    animationName: React.PropTypes.string,
-    style: React.PropTypes.object,
+    direction: PropTypes.string,
+    animationName: PropTypes.string,
+    style: PropTypes.object,
   };
 
   render() {

--- a/src/animations/Slide/SlideIn.js
+++ b/src/animations/Slide/SlideIn.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Slide } from './Slide';
 import { DriverShape } from '../../drivers/DriverShape';
 
@@ -36,17 +37,17 @@ export class SlideIn extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     /**
      * pair of [start, end] values from animation driver, how
      * children would slide in
      */
-    inputRange: React.PropTypes.array,
+    inputRange: PropTypes.array,
     /**
      * position from where wrapped components should slide in
      */
-    from: React.PropTypes.string,
-    style: React.PropTypes.object,
+    from: PropTypes.string,
+    style: PropTypes.object,
   };
 
   render() {

--- a/src/animations/Slide/SlideOut.js
+++ b/src/animations/Slide/SlideOut.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Slide } from './Slide';
 import { DriverShape } from '../../drivers/DriverShape';
 
@@ -36,17 +37,17 @@ export class SlideOut extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     /**
      * pair of [start, end] values from animation driver, how
      * children would slide out
      */
-    inputRange: React.PropTypes.array,
+    inputRange: PropTypes.array,
     /**
      * position to where wrapped components should slide out
      */
-    to: React.PropTypes.string,
-    style: React.PropTypes.object,
+    to: PropTypes.string,
+    style: PropTypes.object,
   };
 
   render() {

--- a/src/animations/ZoomIn.js
+++ b/src/animations/ZoomIn.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
 /*
@@ -36,17 +37,17 @@ export class ZoomIn extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     /**
      * pair of [start, end] values from animation driver, how
      * children would zoom in to maxFactor
      */
-    inputRange: React.PropTypes.array,
+    inputRange: PropTypes.array,
     /**
      * To which factor children would zoom in
      */
-    maxFactor: React.PropTypes.number,
-    style: React.PropTypes.object,
+    maxFactor: PropTypes.number,
+    style: PropTypes.object,
   }
 
   render() {

--- a/src/animations/ZoomOut.js
+++ b/src/animations/ZoomOut.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
 /*
@@ -36,17 +37,17 @@ export class ZoomOut extends Component {
     /**
      * Components to which an effect will be applied
      */
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     /**
      * pair of [start, end] values from animation driver, how
      * children would zoom out from maxFactor
      */
-    inputRange: React.PropTypes.array,
+    inputRange: PropTypes.array,
     /**
      * from which factor children would zoom out
      */
-    maxFactor: React.PropTypes.number,
-    style: React.PropTypes.object,
+    maxFactor: PropTypes.number,
+    style: PropTypes.object,
   }
 
   render() {

--- a/src/components/ZoomableComponent.js
+++ b/src/components/ZoomableComponent.js
@@ -1,7 +1,8 @@
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+
+import PropTypes from 'prop-types';
 
 import {
   View,
@@ -100,7 +101,7 @@ export default function makeZoomable(ComponentToBeDecorated) {
         onStartShouldSetPanResponderCapture: () => true,
         onMoveShouldSetPanResponder: () => true,
         onMoveShouldSetPanResponderCapture: () => true,
-        onPanResponderGrant: () => {},
+        onPanResponderGrant: () => { },
         onPanResponderMove: (evt, gesture) => {
           const touches = evt.nativeEvent.touches;
           const touch1 = touches[0];
@@ -131,7 +132,7 @@ export default function makeZoomable(ComponentToBeDecorated) {
             isMoving: false,
           });
         },
-        onPanResponderTerminate: () => {},
+        onPanResponderTerminate: () => { },
         onShouldBlockNativeResponder: () => true,
       });
     }

--- a/src/components/connectAnimation.js
+++ b/src/components/connectAnimation.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Animated } from 'react-native';
 import hoistStatics from 'hoist-non-react-statics';
 import * as _ from 'lodash';
@@ -21,7 +22,7 @@ function removeAnimationsFromStyle(style) {
  * which contains styles created by animated interpolations
  */
 function transferAnimatedValues(styleValue, animatedStyleValue, key) {
-  if(_.isFunction(animatedStyleValue.interpolate) || _.isUndefined(styleValue)) {
+  if (_.isFunction(animatedStyleValue.interpolate) || _.isUndefined(styleValue)) {
     return animatedStyleValue;
   }
 }
@@ -109,18 +110,18 @@ export function connectAnimation(WrappedComponent, animations = {}, options = de
       /**
        * Component style (could contain animation functions)
        */
-      style: React.PropTypes.object,
+      style: PropTypes.object,
       /**
        * Animation name it should match `${animationName}Animation` function passed in
        * animations collection or component's style.
        * e.g. if animationName is fadeOut there should exist function fadeOutAnimation
        * in animations or style
        */
-      animationName: React.PropTypes.string,
+      animationName: PropTypes.string,
       /**
        * Options that would be passed to animation through context
        */
-      animationOptions: React.PropTypes.object,
+      animationOptions: PropTypes.object,
       /**
        * Explicit animation function declaration with signature:
        * function (driver, context) {
@@ -130,7 +131,7 @@ export function connectAnimation(WrappedComponent, animations = {}, options = de
        * }
        * and it should return style object
        */
-      animation: React.PropTypes.func,
+      animation: PropTypes.func,
     };
 
     static defaultProps = {
@@ -139,11 +140,11 @@ export function connectAnimation(WrappedComponent, animations = {}, options = de
 
     static contextTypes = {
       animationDriver: DriverShape,
-      transformProps: React.PropTypes.func,
+      transformProps: PropTypes.func,
     };
 
     static childContextTypes = {
-      transformProps: React.PropTypes.func,
+      transformProps: PropTypes.func,
     };
 
     constructor(props, context) {

--- a/src/drivers/DriverShape.js
+++ b/src/drivers/DriverShape.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Animated } from 'react-native';
 
-export const DriverShape = React.PropTypes.shape({
-  value: React.PropTypes.instanceOf(Animated.Value),
-  interpolate: React.PropTypes.func,
+export const DriverShape = PropTypes.shape({
+  value: PropTypes.instanceOf(Animated.Value),
+  interpolate: PropTypes.func,
 });


### PR DESCRIPTION
As of React 15.5 PropTypes [has moved](https://facebook.github.io/react/docs/typechecking-with-proptypes.html) to a different package, this changes are to make this package compatible with React 15.5+.