### PR TITLE
Support horizontal scrollviews and onScroll callback

### DIFF
--- a/src/components/connectAnimation.js
+++ b/src/components/connectAnimation.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Animated } from 'react-native';
 import hoistStatics from 'hoist-non-react-statics';
@@ -109,7 +109,7 @@ export function connectAnimation(WrappedComponent, animations = {}, options = de
     Animated.createAnimatedComponent(WrappedComponent) :
     WrappedComponent;
 
-  class AnimatedComponent extends React.PureComponent {
+  class AnimatedComponent extends PureComponent {
     static propTypes = {
       /**
        * Animation Driver an instance of driver that will be used to create animated style
@@ -203,6 +203,7 @@ export function connectAnimation(WrappedComponent, animations = {}, options = de
       return nextProps.style !== this.props.style ||
         nextProps.animation !== this.props.animation ||
         nextProps.animationName !== this.props.animationName ||
+        JSON.stringify(nextProps.animationOptions) !== JSON.stringify(this.props.animationOptions) ||
         this.getDriver(nextProps, nextContext) !== this.getDriver(this.props, this.context);
     }
 

--- a/src/drivers/ScrollDriver.js
+++ b/src/drivers/ScrollDriver.js
@@ -28,7 +28,7 @@ import { DriverBase } from './DriverBase';
  *   Used only if `useNativeDriver` is `true`, defaults to 20ms.
  */
 export class ScrollDriver extends DriverBase {
-  constructor(options = { useNativeDriver: false, nativeScrollEventThrottle: 20 }) {
+  constructor(options = { useNativeDriver: false, horizontal: false, nativeScrollEventThrottle: 20, onScroll: (value) => {} }) {
     super();
 
     if (options.useNativeDriver) {
@@ -36,6 +36,7 @@ export class ScrollDriver extends DriverBase {
 
       this.nativeValue.addListener(_.debounce(({ value }) => {
         this.value.setValue(value);
+        options.onScroll(value)
       }), options.nativeScrollEventThrottle);
     }
 
@@ -44,9 +45,10 @@ export class ScrollDriver extends DriverBase {
     this.onScrollViewLayout = this.onScrollViewLayout.bind(this);
     this.scrollViewProps = {
       onScroll: Animated.event(
-        [{ nativeEvent: { contentOffset: { y: this.primaryValue } } }],
+        [{ nativeEvent: { contentOffset: options.horizontal ? { x: this.primaryValue } : {y: this.primaryValue} } }],
         { useNativeDriver: options.useNativeDriver }
       ),
+      horizontal: options.horizontal,
       scrollEventThrottle: 1,
       onLayout: this.onScrollViewLayout,
     };


### PR DESCRIPTION
Changed the code so that the Scroll driver woks also for horizontal Scrollviews and allows the user to specify a callback on the options to be invoked each time the scroll value changes.

In my case I needed this to manually snap my scrollview which had content with dynamic width.