### PR TITLE
release/0.12.5

### DIFF
--- a/examples/ShoutemAnimation/components/HeroHeader.js
+++ b/examples/ShoutemAnimation/components/HeroHeader.js
@@ -10,7 +10,7 @@ import {
 } from '@shoutem/animation';
 
 import {
-  Image,
+  ImageBackground,
   Tile,
   Title,
   Text,

--- a/examples/ShoutemAnimation/components/Parallax.js
+++ b/examples/ShoutemAnimation/components/Parallax.js
@@ -7,7 +7,7 @@ import {
 } from '@shoutem/animation';
 
 import {
-  Image,
+  ImageBackground,
   Tile,
   Title,
   Subtitle,

--- a/examples/ShoutemAnimation/package.json
+++ b/examples/ShoutemAnimation/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"babel-jest": "21.2.0",
-		"babel-preset-react-native": "4.0.0",
+		"babel-preset-react-native": "^5.0.1",
 		"jest": "21.2.1",
 		"react-test-renderer": "16.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/animation",
-  "version": "0.12.2",
+  "version": "0.12.4",
   "description": "Shoutem Animation Library",
   "main": "index.js",
   "repository": {

--- a/src/animations/FadeIn.js
+++ b/src/animations/FadeIn.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
@@ -27,7 +27,7 @@ import { DriverShape } from '../drivers/DriverShape';
  * from scroll position 100, to scroll position 150 where image is fully transparent at
  * scroll position 100, and opaque at scroll position 150
  */
-export class FadeIn extends Component {
+export class FadeIn extends PureComponent {
   static propTypes = {
     /**
      * An instance of animation driver, usually ScrollDriver

--- a/src/animations/FadeOut.js
+++ b/src/animations/FadeOut.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
@@ -27,7 +27,7 @@ import { DriverShape } from '../drivers/DriverShape';
  * from scroll 100, to scroll 150 where image is opaque at scroll 100,
  * and fully transparent at scroll 150
  */
-export class FadeOut extends Component {
+export class FadeOut extends PureComponent {
   static propTypes = {
     /**
      * An instance of animation driver, usually ScrollDriver

--- a/src/animations/HeroHeader.js
+++ b/src/animations/HeroHeader.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
@@ -27,7 +27,7 @@ import { DriverShape } from '../drivers/DriverShape';
  * where image will be scrolled 1.5 times faster than Title and the image will have
  * a zoom in effect when the scroll reaches the top of the screen (on bounce)
  */
-export class HeroHeader extends Component {
+export class HeroHeader extends PureComponent {
   static propTypes = {
     driver: DriverShape.isRequired,
     /**

--- a/src/animations/Parallax.js
+++ b/src/animations/Parallax.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactNative, { Animated, View, Dimensions } from 'react-native';
 
@@ -31,7 +31,7 @@ import { measure } from '../components/measure';
  * Above code will create scroll dependent parallax animation over Image component
  * where image will be scrolled 2 times faster than Title
  */
-class Parallax extends Component {
+class Parallax extends PureComponent {
   static propTypes = {
     /**
      * An instance of animation driver, usually ScrollDriver
@@ -76,15 +76,14 @@ class Parallax extends Component {
   }
 
   calculateTranslation(scrollOffset) {
-    const { pageY } = this.state.layout;
-    const { driver } = this.props;
-    const scrollHeight = driver.layout.height;
+    const { layout: { pageY } } = this.state;
+    const { driver: { layout: { height: scrollHeight } } } = this.props;
     this.translation.setValue(scrollOffset.value - (pageY - scrollHeight / 2));
   }
 
-  componentWillMount() {
-    const { driver } = this.props;
-    this.animationListener = driver.value.addListener(this.calculateTranslation);
+  componentDidMount() {
+    const { driver: { value: { addlistener } } } = this.props;
+    this.animationListener = addListener(this.calculateTranslation);
   }
 
   componentWillUnmount() {

--- a/src/animations/Rotate.js
+++ b/src/animations/Rotate.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
@@ -26,7 +26,7 @@ import { DriverShape } from '../drivers/DriverShape';
  * ...
  * Above code will create scroll dependent rotation of an Image by 180 degrees
  */
-export class Rotate extends Component {
+export class Rotate extends PureComponent {
   static propTypes = {
     /**
      * An instance of animation driver, usually ScrollDriver

--- a/src/animations/Slide/Slide.js
+++ b/src/animations/Slide/Slide.js
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { View } from './../View';
 import { DriverShape } from '../../drivers/DriverShape';
 import { measure } from '../../components/measure';
 
-class Slide extends Component {
+class Slide extends PureComponent {
   static propTypes = {
     /**
      * An instance of animation driver, usually ScrollDriver

--- a/src/animations/Slide/SlideIn.js
+++ b/src/animations/Slide/SlideIn.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Slide } from './Slide';
 import { DriverShape } from '../../drivers/DriverShape';
@@ -28,7 +28,7 @@ import { DriverShape } from '../../drivers/DriverShape';
  * Above code will create scroll dependent slide in of an Image to
  * the top right corner of the screen between scroll position of 100 and 150
  */
-export class SlideIn extends Component {
+export class SlideIn extends PureComponent {
   static propTypes = {
     /**
      * An instance of animation driver, usually ScrollDriver

--- a/src/animations/Slide/SlideOut.js
+++ b/src/animations/Slide/SlideOut.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Slide } from './Slide';
 import { DriverShape } from '../../drivers/DriverShape';
@@ -28,7 +28,7 @@ import { DriverShape } from '../../drivers/DriverShape';
  * Above code will create scroll dependent slide out of an Image to
  * the top left corner of the screen between scroll position of 100 and 150
  */
-export class SlideOut extends Component {
+export class SlideOut extends PureComponent {
   static propTypes = {
     /**
      * An instance of animation driver, usually ScrollDriver

--- a/src/animations/ZoomIn.js
+++ b/src/animations/ZoomIn.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
@@ -28,7 +28,7 @@ import { DriverShape } from '../drivers/DriverShape';
  * from scroll 100, to scroll 150 where image has original size at scroll 100,
  * and is scaled by maxFactor at scroll 150
  */
-export class ZoomIn extends Component {
+export class ZoomIn extends PureComponent {
   static propTypes = {
     /**
      * An instance of animation driver, usually ScrollDriver

--- a/src/animations/ZoomOut.js
+++ b/src/animations/ZoomOut.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { View } from './View';
 import { DriverShape } from '../drivers/DriverShape';
@@ -28,7 +28,7 @@ import { DriverShape } from '../drivers/DriverShape';
  * from scroll 100, to scroll 150 where image is scaled by maxFactor at scroll 100,
  * and has original size at scroll 150
  */
-export class ZoomOut extends Component {
+export class ZoomOut extends PureComponent {
   static propTypes = {
     /**
      * An instance of animation driver, usually ScrollDriver

--- a/src/components/ZoomableComponent.js
+++ b/src/components/ZoomableComponent.js
@@ -1,6 +1,4 @@
-import React, {
-  Component,
-} from 'react';
+import React, { PureComponent } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -62,7 +60,7 @@ export default function makeZoomable(ComponentToBeDecorated) {
    * within the view and updates the style of the decorated component with new values
    * for width, height and absolute position.
    */
-  class ZoomDecorator extends Component {
+  class ZoomDecorator extends PureComponent {
     static propTypes = {
       componentWidth: PropTypes.number.isRequired,
       componentHeight: PropTypes.number.isRequired,
@@ -95,7 +93,7 @@ export default function makeZoomable(ComponentToBeDecorated) {
       };
     }
 
-    componentWillMount() {
+    componentDidMount() {
       this._panResponder = PanResponder.create({
         onStartShouldSetPanResponder: () => true,
         onStartShouldSetPanResponderCapture: () => true,
@@ -258,4 +256,3 @@ export default function makeZoomable(ComponentToBeDecorated) {
 
   return ZoomDecorator;
 }
-


### PR DESCRIPTION
Remove deprecated lifecycle methods and reduce rerendering.

Bumped to 0.12.5 version due to having accidentally published and then having to unpublish 0.12.4. Functionally no difference exists between the two versions.