### PR TITLE
Remove isRequired from driver prop

### DIFF
--- a/src/components/connectAnimation.js
+++ b/src/components/connectAnimation.js
@@ -130,7 +130,7 @@ export default function connectAnimation(
       /**
        * Animation Driver an instance of driver that will be used to create animated style
        */
-      driver: DriverShape.isRequired,
+      driver: DriverShape,
       /**
        * Component style (could contain animation functions)
        */


### PR DESCRIPTION
While ideally we'd keep this, as the driver really is required in order to apply animations, the issue is that it's often not provided and is expected to be resolved via context, as seen in `getDriver` in `connectAnimation`:
```
getDriver(props = this.props, context = this.context) {
  return props.driver || context.animationDriver;
}
```

If there's a way to set the `defaultProps`, that would be a good alternative, but I don't think there's a reasonable default to this.

I suggest checking the `connectAnimation.js` file in its entirety for more context if necessary.