### PR TITLE
Sync master into develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/animation",
-  "version": "1.0.1-rc.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/animation",
-      "version": "1.0.1-rc.0",
+      "version": "1.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "auto-bind": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/animation",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/animation",
-      "version": "1.0.0",
+      "version": "1.0.1-rc.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "auto-bind": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/animation",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.0",
   "description": "Shoutem Animation Library",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/animation",
-  "version": "1.0.1-rc.0",
+  "version": "1.0.1",
   "description": "Shoutem Animation Library",
   "main": "index.js",
   "scripts": {

--- a/src/animations/Wiggle.js
+++ b/src/animations/Wiggle.js
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
+import { Animated, Easing, Platform } from 'react-native';
 import autoBindReact from 'auto-bind/react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import { Animated, Easing, Platform } from 'react-native';
 
+const webHeight = { height: Platform.OS === 'web' ? '100%' : undefined };
 export default class Wiggle extends PureComponent {
   constructor(props) {
     super(props);
@@ -47,11 +48,12 @@ export default class Wiggle extends PureComponent {
     const animatedStyle = {
       paddingHorizontal,
       transform: [{ translateX: interpolated }],
-      ...(Platform.OS === "web" && { height: '100%' })
     };
 
     return (
-      <Animated.View style={[style, animatedStyle]}>{children}</Animated.View>
+      <Animated.View style={[webHeight, style, animatedStyle]}>
+        {children}
+      </Animated.View>
     );
   }
 }


### PR DESCRIPTION
Unintentionally pushed changes directly into master, instead of making hotfix.
Syncing it into dev branch.

Changes done as a part of 1.0.1:
Before, we've had to specify height for Wiggle component when platform === web.
I believe it fixed some ui issue somewhere, but that's not the correct style to use & it broke UI in my implementation.

Because I'm unaware of all implementations and I'm afraid my changes could break UI somewhere, I've only allowed for that style override, keeping backward compatibility.
I'm assuming flex:1 would work everywhere, but I can't confirm 100%.